### PR TITLE
fix: change dts chip compatibility

### DIFF
--- a/meta-aesd/recipes-i2c-driver/images/core-image-aesd.bb
+++ b/meta-aesd/recipes-i2c-driver/images/core-image-aesd.bb
@@ -1,6 +1,6 @@
 inherit core-image
 IMAGE_INSTALL:append = " i2c-tools"
-KERNEL_MODULE_AUTOLOAD:raspberrypi4-64 = " i2c-dev i2c-bcm2835"
+KERNEL_MODULE_AUTOLOAD:raspberrypi4-64 = " i2c-dev i2c-bcm2711"
 CORE_IMAGE_EXTRA_INSTALL += "aesd-i2c-driver"
 
 # Add the custom overlay to the boot partition

--- a/meta-aesd/recipes-kernel/linux/linux-raspberrypi/lcd1602-overlay.dts
+++ b/meta-aesd/recipes-kernel/linux/linux-raspberrypi/lcd1602-overlay.dts
@@ -2,7 +2,7 @@
 /plugin/;
 
 / {
-    compatible = "brcm,bcm2835";
+    compatible = "brcm,bcm2711";
 
     fragment@0 {
         target = <&i2c1>;


### PR DESCRIPTION
- in dts overlay the compatibility definition is wrong - should be bcm2711, which is the rapi 4 chip